### PR TITLE
JCPM-53 Change Modified timestamp when updating Products and Components

### DIFF
--- a/src/main/java/com/theroom307/jcpm/core/data/repository/ItemRepository.java
+++ b/src/main/java/com/theroom307/jcpm/core/data/repository/ItemRepository.java
@@ -2,21 +2,6 @@ package com.theroom307.jcpm.core.data.repository;
 
 import com.theroom307.jcpm.core.data.model.Item;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.lang.NonNull;
-import org.springframework.transaction.annotation.Transactional;
 
 public interface ItemRepository<T extends Item> extends JpaRepository<T, Long> {
-
-    @Transactional
-    @Modifying
-    @Query("update #{#entityName} t set t.name = ?1 where t.id = ?2")
-    void updateNameById(String name, @NonNull Long itemId);
-
-    @Transactional
-    @Modifying
-    @Query("update #{#entityName} t set t.description = ?1 where t.id = ?2")
-    void updateDescriptionById(String description, @NonNull Long itemId);
-
 }

--- a/src/main/java/com/theroom307/jcpm/core/service/impl/ItemServiceImpl.java
+++ b/src/main/java/com/theroom307/jcpm/core/service/impl/ItemServiceImpl.java
@@ -74,14 +74,22 @@ public abstract class ItemServiceImpl<T extends Item> implements ItemService<T> 
         var item = repository.findById(id)
                 .orElseThrow(() -> new ItemNotFoundException(itemType, id));
 
+        boolean changed = false;
+
         if (newName != null && !item.getName().equals(newName)) {
             log.info("Setting the {} name for {} to '{}'", itemType, id, newName);
-            repository.updateNameById(newName, id);
+            item.setName(newName);
+            changed = true;
         }
 
         if (newDescription != null && !item.getDescription().equals(newDescription)) {
             log.info("Setting the {} description for {} to '{}'", itemType, id, newDescription);
-            repository.updateDescriptionById(newDescription, id);
+            item.setDescription(newDescription);
+            changed = true;
+        }
+
+        if (changed) {
+            repository.save(item);
         }
     }
 

--- a/src/test/java/com/theroom307/jcpm/core/integrationtests/ComponentLifecycleTests.java
+++ b/src/test/java/com/theroom307/jcpm/core/integrationtests/ComponentLifecycleTests.java
@@ -12,11 +12,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.time.ZonedDateTime;
-import java.util.function.Predicate;
-
 import static com.theroom307.jcpm.core.TestTypes.INTEGRATION_TEST;
 import static com.theroom307.jcpm.core.utils.data.TestComponentData.*;
+import static java.util.function.Predicate.not;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -101,6 +99,8 @@ class ComponentLifecycleTests {
         component.setDescription("Component description before editing.");
         final var originalComponent = componentRepository.save(component);
 
+        Thread.sleep(10); // to test the modified timestamp
+
         mockMvc
                 .perform(patch(String.format(COMPONENT_ENDPOINT, originalComponent.getId()))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -121,23 +121,18 @@ class ComponentLifecycleTests {
                 .hasFieldOrPropertyWithValue("description", getComponent().getDescription())
                 .as("The created timestamp should not change")
                 .extracting(Component::getCreated)
-                .matches(isEqualTo(originalComponent.getCreated()),
+                .matches(originalComponent.getCreated()::isEqual,
                         "should be " + originalComponent.getCreated());
 
-        // TODO: Test the modified timestamp updating after JCPM-53 is fixed
-//        assertThat(editedComponent)
-//                .get()
-//                .extracting(Component::getModified)
-//                .as("The modified timestamp should have changed")
-//                .matches(not(isEqualTo(originalComponent.getModified())),
-//                        "should be after " + originalComponent.getModified())
-//                .as("The modified timestamp should be after the original value")
-//                .matches((modified) -> modified.isAfter(originalComponent.getModified()),
-//                        "should be after " + originalComponent.getModified());
-    }
-
-    private Predicate<ZonedDateTime> isEqualTo(ZonedDateTime expected) {
-        return (actual) -> actual.toEpochSecond() == expected.toEpochSecond();
+        assertThat(editedComponent)
+                .get()
+                .extracting(Component::getModified)
+                .as("The modified timestamp should have changed")
+                .matches(not(originalComponent.getModified()::isEqual),
+                        "should be after " + originalComponent.getModified())
+                .as("The modified timestamp should be after the original value")
+                .matches((modified) -> modified.isAfter(originalComponent.getModified()),
+                        "should be after " + originalComponent.getModified());
     }
 
     @Test

--- a/src/test/java/com/theroom307/jcpm/core/integrationtests/ProductLifecycleTests.java
+++ b/src/test/java/com/theroom307/jcpm/core/integrationtests/ProductLifecycleTests.java
@@ -12,11 +12,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.time.ZonedDateTime;
-import java.util.function.Predicate;
-
 import static com.theroom307.jcpm.core.TestTypes.INTEGRATION_TEST;
 import static com.theroom307.jcpm.core.utils.data.TestProductData.*;
+import static java.util.function.Predicate.not;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -101,6 +99,8 @@ class ProductLifecycleTests {
         product.setDescription("Product description before editing.");
         final var originalProduct = productRepository.save(product);
 
+        Thread.sleep(10); // to test the modified timestamp
+
         mockMvc
                 .perform(patch(String.format(PRODUCT_ENDPOINT, originalProduct.getId()))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -121,23 +121,18 @@ class ProductLifecycleTests {
                 .hasFieldOrPropertyWithValue("description", getProduct().getDescription())
                 .as("The created timestamp should not change")
                 .extracting(Product::getCreated)
-                .matches(isEqualTo(originalProduct.getCreated()),
+                .matches(originalProduct.getCreated()::isEqual,
                         "should be " + originalProduct.getCreated());
 
-        // TODO: Test the modified timestamp updating after JCPM-53 is fixed
-//        assertThat(editedProduct)
-//                .get()
-//                .extracting(Product::getModified)
-//                .as("The modified timestamp should have changed")
-//                .matches(not(isEqualTo(originalProduct.getModified())),
-//                        "should be after " + originalProduct.getModified())
-//                .as("The modified timestamp should be after the original value")
-//                .matches((modified) -> modified.isAfter(originalProduct.getModified()),
-//                        "should be after " + originalProduct.getModified());
-    }
-
-    private Predicate<ZonedDateTime> isEqualTo(ZonedDateTime expected) {
-        return (actual) -> actual.toEpochSecond() == expected.toEpochSecond();
+        assertThat(editedProduct)
+                .get()
+                .extracting(Product::getModified)
+                .as("The modified timestamp should have changed")
+                .matches(not(originalProduct.getModified()::isEqual),
+                        "should be after " + originalProduct.getModified())
+                .as("The modified timestamp should be after the original value")
+                .matches((modified) -> modified.isAfter(originalProduct.getModified()),
+                        "should be after " + originalProduct.getModified());
     }
 
     @Test

--- a/src/test/java/com/theroom307/jcpm/core/unittests/service/component/ComponentServiceTests.java
+++ b/src/test/java/com/theroom307/jcpm/core/unittests/service/component/ComponentServiceTests.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -125,11 +126,17 @@ class ComponentServiceTests {
         var editedComponent = new Component();
         editedComponent.setName("New Component Name");
 
-        when(componentRepository.findById(anyLong())).thenReturn(Optional.of(getComponent()));
+        var originalComponent = getComponent();
+        when(componentRepository.findById(anyLong())).thenReturn(Optional.of(originalComponent));
 
         componentService.editItem(VALID_COMPONENT_ID, editedComponent);
 
-        verify(componentRepository).updateNameById("New Component Name", VALID_COMPONENT_ID);
+        var captor = ArgumentCaptor.forClass(Component.class);
+        verify(componentRepository).save(captor.capture());
+
+        Component savedComponent = captor.getValue();
+        assertThat(savedComponent.getName()).isEqualTo("New Component Name");
+        assertThat(savedComponent.getDescription()).isEqualTo(originalComponent.getDescription());
     }
 
     @Test
@@ -137,11 +144,17 @@ class ComponentServiceTests {
         var editedComponent = new Component();
         editedComponent.setDescription("New component description.");
 
-        when(componentRepository.findById(anyLong())).thenReturn(Optional.of(getComponent()));
+        var originalComponent = getComponent();
+        when(componentRepository.findById(anyLong())).thenReturn(Optional.of(originalComponent));
 
         componentService.editItem(VALID_COMPONENT_ID, editedComponent);
 
-        verify(componentRepository).updateDescriptionById("New component description.", VALID_COMPONENT_ID);
+        var captor = ArgumentCaptor.forClass(Component.class);
+        verify(componentRepository).save(captor.capture());
+
+        Component savedComponent = captor.getValue();
+        assertThat(savedComponent.getName()).isEqualTo(originalComponent.getName());
+        assertThat(savedComponent.getDescription()).isEqualTo("New component description.");
     }
 
     @Test
@@ -150,12 +163,17 @@ class ComponentServiceTests {
         editedComponent.setName("New Component Name");
         editedComponent.setDescription("New component description.");
 
-        when(componentRepository.findById(anyLong())).thenReturn(Optional.of(getComponent()));
+        var originalComponent = getComponent();
+        when(componentRepository.findById(anyLong())).thenReturn(Optional.of(originalComponent));
 
         componentService.editItem(VALID_COMPONENT_ID, editedComponent);
 
-        verify(componentRepository).updateNameById("New Component Name", VALID_COMPONENT_ID);
-        verify(componentRepository).updateDescriptionById("New component description.", VALID_COMPONENT_ID);
+        var captor = ArgumentCaptor.forClass(Component.class);
+        verify(componentRepository).save(captor.capture());
+
+        Component savedComponent = captor.getValue();
+        assertThat(savedComponent.getName()).isEqualTo("New Component Name");
+        assertThat(savedComponent.getDescription()).isEqualTo("New component description.");
     }
 
     @Test

--- a/src/test/java/com/theroom307/jcpm/core/unittests/service/product/ProductServiceTests.java
+++ b/src/test/java/com/theroom307/jcpm/core/unittests/service/product/ProductServiceTests.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -125,11 +126,17 @@ class ProductServiceTests {
         var editedProduct = new Product();
         editedProduct.setName("New Product Name");
 
-        when(productRepository.findById(anyLong())).thenReturn(Optional.of(getProduct()));
+        var originalProduct = getProduct();
+        when(productRepository.findById(anyLong())).thenReturn(Optional.of(originalProduct));
 
         productService.editItem(VALID_PRODUCT_ID, editedProduct);
 
-        verify(productRepository).updateNameById("New Product Name", VALID_PRODUCT_ID);
+        var captor = ArgumentCaptor.forClass(Product.class);
+        verify(productRepository).save(captor.capture());
+
+        var savedProduct = captor.getValue();
+        assertThat(savedProduct.getName()).isEqualTo("New Product Name");
+        assertThat(savedProduct.getDescription()).isEqualTo(originalProduct.getDescription());
     }
 
     @Test
@@ -137,11 +144,17 @@ class ProductServiceTests {
         var editedProduct = new Product();
         editedProduct.setDescription("New product description.");
 
-        when(productRepository.findById(anyLong())).thenReturn(Optional.of(getProduct()));
+        var originalProduct = getProduct();
+        when(productRepository.findById(anyLong())).thenReturn(Optional.of(originalProduct));
 
         productService.editItem(VALID_PRODUCT_ID, editedProduct);
 
-        verify(productRepository).updateDescriptionById("New product description.", VALID_PRODUCT_ID);
+        var captor = ArgumentCaptor.forClass(Product.class);
+        verify(productRepository).save(captor.capture());
+
+        Product savedProduct = captor.getValue();
+        assertThat(savedProduct.getName()).isEqualTo(originalProduct.getName());
+        assertThat(savedProduct.getDescription()).isEqualTo("New product description.");
     }
 
     @Test
@@ -150,12 +163,17 @@ class ProductServiceTests {
         editedProduct.setName("New Product Name");
         editedProduct.setDescription("New product description.");
 
-        when(productRepository.findById(anyLong())).thenReturn(Optional.of(getProduct()));
+        var originalProduct = getProduct();
+        when(productRepository.findById(anyLong())).thenReturn(Optional.of(originalProduct));
 
         productService.editItem(VALID_PRODUCT_ID, editedProduct);
 
-        verify(productRepository).updateNameById("New Product Name", VALID_PRODUCT_ID);
-        verify(productRepository).updateDescriptionById("New product description.", VALID_PRODUCT_ID);
+        var captor = ArgumentCaptor.forClass(Product.class);
+        verify(productRepository).save(captor.capture());
+
+        Product savedProduct = captor.getValue();
+        assertThat(savedProduct.getName()).isEqualTo("New Product Name");
+        assertThat(savedProduct.getDescription()).isEqualTo("New product description.");
     }
 
     @Test


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed modified timestamp not updating when editing Products and Components

- Replaced custom JPQL update queries with entity save operations

- Updated unit and integration tests to verify timestamp behavior

- Cleaned up unused imports and helper methods


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Custom JPQL Updates"] --> B["Entity Save Operations"]
  B --> C["Modified Timestamp Updated"]
  D["Broken Tests"] --> E["Fixed Tests"]
  E --> F["Timestamp Verification"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ItemRepository.java</strong><dd><code>Remove custom JPQL update methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/theroom307/jcpm/core/data/repository/ItemRepository.java

<ul><li>Removed custom JPQL update methods <code>updateNameById</code> and <br><code>updateDescriptionById</code><br> <li> Cleaned up unused imports for <code>@Modifying</code>, <code>@Query</code>, and <code>@Transactional</code></ul>


</details>


  </td>
  <td><a href="https://github.com/mykavr/jcpm-core-app/pull/33/files#diff-b595a76ca7ae63ec337e627a59b166e1b12cc541d0cf16ef2ed67c4d512d7d72">+0/-15</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ItemServiceImpl.java</strong><dd><code>Replace JPQL updates with entity save operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/theroom307/jcpm/core/service/impl/ItemServiceImpl.java

<ul><li>Replaced direct repository update calls with entity modification and <br>save<br> <li> Added change tracking to only save when modifications occur<br> <li> Modified entities in-memory before saving to trigger timestamp updates</ul>


</details>


  </td>
  <td><a href="https://github.com/mykavr/jcpm-core-app/pull/33/files#diff-23a29f63483eb604f35a5ed7e4f3ef69eba3c70ae9ea12de065eee520bfd96df">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ComponentLifecycleTests.java</strong><dd><code>Enable modified timestamp verification tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/java/com/theroom307/jcpm/core/integrationtests/ComponentLifecycleTests.java

<ul><li>Added sleep delay to ensure timestamp difference in tests<br> <li> Enabled previously commented modified timestamp assertions<br> <li> Simplified timestamp comparison using method references<br> <li> Removed unused helper method <code>isEqualTo</code></ul>


</details>


  </td>
  <td><a href="https://github.com/mykavr/jcpm-core-app/pull/33/files#diff-8669e957808ce73062ef235f1b61e8782f7a887d4b7515f31f1c28543d279561">+13/-18</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ProductLifecycleTests.java</strong><dd><code>Enable modified timestamp verification tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/java/com/theroom307/jcpm/core/integrationtests/ProductLifecycleTests.java

<ul><li>Added sleep delay to ensure timestamp difference in tests<br> <li> Enabled previously commented modified timestamp assertions<br> <li> Simplified timestamp comparison using method references<br> <li> Removed unused helper method <code>isEqualTo</code></ul>


</details>


  </td>
  <td><a href="https://github.com/mykavr/jcpm-core-app/pull/33/files#diff-00b1b2c89de48a92146a1eff1afd09521ebbb0778694c66c73f725eeea0eb944">+13/-18</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ComponentServiceTests.java</strong><dd><code>Update unit tests for entity save operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/java/com/theroom307/jcpm/core/unittests/service/component/ComponentServiceTests.java

<ul><li>Updated tests to verify <code>save()</code> method calls instead of custom update <br>methods<br> <li> Added <code>ArgumentCaptor</code> to capture and verify saved entity state<br> <li> Enhanced assertions to check both name and description fields</ul>


</details>


  </td>
  <td><a href="https://github.com/mykavr/jcpm-core-app/pull/33/files#diff-9356c3dd747ffeab70d4b1f0f39fbadb47132bae0f9d712c71d809585c72a468">+25/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ProductServiceTests.java</strong><dd><code>Update unit tests for entity save operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/java/com/theroom307/jcpm/core/unittests/service/product/ProductServiceTests.java

<ul><li>Updated tests to verify <code>save()</code> method calls instead of custom update <br>methods<br> <li> Added <code>ArgumentCaptor</code> to capture and verify saved entity state<br> <li> Enhanced assertions to check both name and description fields</ul>


</details>


  </td>
  <td><a href="https://github.com/mykavr/jcpm-core-app/pull/33/files#diff-fe9f1b4e8f2aa2d75feb6ebc6152217d96a0e171ad9ec85bc5c5b682a5462480">+25/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

